### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HAWQ Samples Repository
 
-The `hawq-samples` repository includes the sample data set and scripts referenced by the "Getting Started With HAWQ" tutorial. This tutorial is currently accessible from the [Pivotal HDB](http://hdb.docs.pivotal.io/220/hawq/tutorial/overview.html) documentation set. 
+The `hawq-samples` repository includes the sample data set and scripts referenced by the "Getting Started With HAWQ" tutorial. This tutorial is currently accessible from the [Pivotal HDB](https://hdb.docs.pivotal.io/220/hawq/tutorial/overview.html) documentation set. 
 
 This repository may be extended in the future to include other HAWQ-related tutorials, sample code, demos, etc.
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://hdb.docs.pivotal.io/220/hawq/tutorial/overview.html with 1 occurrences migrated to:  
  https://hdb.docs.pivotal.io/220/hawq/tutorial/overview.html ([https](https://hdb.docs.pivotal.io/220/hawq/tutorial/overview.html) result 200).